### PR TITLE
changed the npm start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "styled-components": "^5.3.6"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "react-scripts --openssl-legacy-provider start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
FIXES : 
Error while setting up the project locally #61

I searched for the solution on stackoverflow , it suggested me to change the start script from "start": "react-scripts start", to "start": "react-scripts --openssl-legacy-provider start"  in package.json . 
I tried this and project started running successfully 